### PR TITLE
Fix Issue 3

### DIFF
--- a/.github/test_conda_env.yml
+++ b/.github/test_conda_env.yml
@@ -9,4 +9,3 @@ dependencies:
   - pip
   - pip:
       - pytest-cov
-

--- a/dbscan1d/core.py
+++ b/dbscan1d/core.py
@@ -35,6 +35,10 @@ class DBSCAN1D:
     def _assign_core_group_numbers(self, cores):
         """ Given a group of core points, assign group numbers to each. """
         gt_eps = abs(cores - np.roll(cores, 1)) > self.eps
+        # The first value doesn't need to be compared to last, set to False so
+        # that cluster names are consistent (see issue #3).
+        if len(gt_eps):
+            gt_eps[0] = False
         return gt_eps.astype(int).cumsum()
 
     def _bound_on(self, arr, max_len):

--- a/tests/test_dbscan1d.py
+++ b/tests/test_dbscan1d.py
@@ -116,17 +116,13 @@ class TestIssues:
 
     def test_issue_3(self):
         """
-        Test that cluster numbers remain concistent for 1 cluster. See issue #3.
+        Test that cluster numbers remain consistent for 1 cluster. See issue #3.
         """
-        label_is_zero = [86400.0, 86400.0, 86400.0, 86401.0, 86399.0, 86400.0, 86401.0, 86399.0, 86400.0, 86400.0,
-                         86400.0, 86402.0, 86398.0, 86401.0, 86399.0, 86401.0, 86400.0, 86399.0, 86399.0, 86401.0,
-                         86399.0, 86401.0, 86399.0, 86402.0, 86399.0, 86400.0, 86401.0, 86401.0]
-
-        label_is_one = [46823, 46818, 46816, 46816, 46819]
-
-        out1 = DBSCAN1D().fit_predict(np.array(label_is_one))
-
-        out2 = DBSCAN1D().fit_predict(np.array(label_is_zero))
-
-        breakpoint()
-
+        ar1 = [86400.0, 86401.0, 86399.0, 86401.0, 86399.0, 86401.0]
+        ar2 = [46823, 46818, 46816, 46816, 46819]
+        dbscan = DBSCAN1D(eps=5, min_samples=3)
+        # Group names should be sequential, starting with zero
+        out1 = dbscan.fit_predict(np.array(ar2))
+        out2 = dbscan.fit_predict(np.array(ar1))
+        assert set(out1) == {0}
+        assert set(out2) == {0}

--- a/tests/test_dbscan1d.py
+++ b/tests/test_dbscan1d.py
@@ -62,7 +62,7 @@ def generate_test_data(num_points, centers=None):
 # --- tests cases
 
 
-class TestSKleanEquivilent:
+class TestSKleanEquivalent:
     """
     Basic tests for DBSCAN1D.
 
@@ -109,3 +109,24 @@ class TestSKleanEquivilent:
         assert unclusterd_equal(out1, out2)
         # Now assert the same points fall in the same cluster groups
         assert clusters_equivalent(out1, out2)
+
+
+class TestIssues:
+    """Tests for issues filled on github."""
+
+    def test_issue_3(self):
+        """
+        Test that cluster numbers remain concistent for 1 cluster. See issue #3.
+        """
+        label_is_zero = [86400.0, 86400.0, 86400.0, 86401.0, 86399.0, 86400.0, 86401.0, 86399.0, 86400.0, 86400.0,
+                         86400.0, 86402.0, 86398.0, 86401.0, 86399.0, 86401.0, 86400.0, 86399.0, 86399.0, 86401.0,
+                         86399.0, 86401.0, 86399.0, 86402.0, 86399.0, 86400.0, 86401.0, 86401.0]
+
+        label_is_one = [46823, 46818, 46816, 46816, 46819]
+
+        out1 = DBSCAN1D().fit_predict(np.array(label_is_one))
+
+        out2 = DBSCAN1D().fit_predict(np.array(label_is_zero))
+
+        breakpoint()
+


### PR DESCRIPTION
Addresses #3. The problem was with a numpy.roll in _assign_core_group_numbers comparing the distance between the first core point and the last core point, which is meaningless anyway. 